### PR TITLE
Manushree635 issue#19856

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1124,7 +1124,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
         """
         if self.locator is None:
             if self.logscale:
-                self.locator = ticker.LogLocator()
+                self.locator = ticker.LogLocator(numticks=N)
             else:
                 self.locator = ticker.MaxNLocator(N + 1, min_n_ticks=1)
 

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1124,7 +1124,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
         """
         if self.locator is None:
             if self.logscale:
-                self.locator = ticker.LogLocator(numticksN)
+                self.locator = ticker.LogLocator(numticks=N)
             else:
                 self.locator = ticker.MaxNLocator(N + 1, min_n_ticks=1)
 

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1124,7 +1124,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
         """
         if self.locator is None:
             if self.logscale:
-                self.locator = ticker.LogLocator(numticks=N)
+                self.locator = ticker.LogLocator(numticksN)
             else:
                 self.locator = ticker.MaxNLocator(N + 1, min_n_ticks=1)
 


### PR DESCRIPTION
## PR Summary
## Issue #19856
Contour plots don't interact nicely with matplotlib.colors.LogNorm. levels=N doesn't work for LogNorm.
So added argument numticks=N in def _autolev(self, N) which would solve the issue
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ N/A] Has pytest style unit tests (and `pytest` passes).
- [N/A ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ N/A] New features are documented, with examples if plot related.
- [ N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ N/A] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
